### PR TITLE
Header to turn off screen split and status line

### DIFF
--- a/hdr.awk
+++ b/hdr.awk
@@ -3,7 +3,7 @@ function hdr_init() {
 # Fix header flags:
 # reset bit 4 (status line available)
 # reset bit 5 (split screen available)
-    hdr_flags = and(mem_read_u8(1),207)
+    hdr_flags = logand(mem_read_u8(1),207)
     mem_write_u8(1, hdr_flags)
     hdr_high_memory_offset = mem_read_u16(4)
     hdr_initial_pc = mem_read_u16(6)

--- a/hdr.awk
+++ b/hdr.awk
@@ -1,5 +1,10 @@
 function hdr_init() {
     hdr_version = mem_read_u8(0)
+# Fix header flags:
+# reset bit 4 (status line available)
+# reset bit 5 (split screen available)
+    hdr_flags = and(mem_read_u8(1),207)
+    mem_write_u8(1, hdr_flags)
     hdr_high_memory_offset = mem_read_u16(4)
     hdr_initial_pc = mem_read_u16(6)
     hdr_dictionary_offset = mem_read_u16(8)

--- a/z.awk
+++ b/z.awk
@@ -1,8 +1,9 @@
 
 
 function z_main() {
-    mem_init()
+
     hdr_init()
+    mem_init()
 
     if(hdr_version != 3) {
         printf ("ZAWK Z-Machine/Infocom Interactive fiction interpreter\n")


### PR DESCRIPTION
Have updated for header to turn off split screen and status line available flags. Reordered load so that header is tweaked before restore copy is taken.