### PR TITLE
Implement 0op 4: NOP

### DIFF
--- a/op.awk
+++ b/op.awk
@@ -111,6 +111,8 @@ function op_dispatch_0op() {
         cpu_pc = txt_print(cpu_pc)
         printf("\n")
         cpu_ret(1)
+    } else if(op_code == 4) {
+        # nop
     } else if(op_code == 7) {
         # restart
         restart_game()


### PR DESCRIPTION
While NOP really doesn't turn up often, it does turn up in `ziptest.z3`. This is needed to run through to the random number test.