### PR TITLE
Add code stubs for save and restore

### DIFF
--- a/hdr.awk
+++ b/hdr.awk
@@ -1,8 +1,8 @@
 function hdr_init() {
     hdr_version = mem_read_u8(0)
 # Fix header flags:
-# reset bit 4 (status line available)
-# reset bit 5 (split screen available)
+# reset bit 4 (status line is not available)
+# reset bit 5 (split screen is not available)
     hdr_flags = logand(mem_read_u8(1),207)
     mem_write_u8(1, hdr_flags)
     hdr_high_memory_offset = mem_read_u16(4)
@@ -29,4 +29,13 @@ function restart_game() {
     mem_restore()
     cpu_init()
     stack_init()
+}
+
+#code stubs for save and restore
+function save_game () {
+    return 0
+}
+
+function restore_game () {
+    return 0
 }

--- a/op.awk
+++ b/op.awk
@@ -113,6 +113,12 @@ function op_dispatch_0op() {
         cpu_ret(1)
     } else if(op_code == 4) {
         # nop
+    } else if(op_code == 5) {
+        # save
+        cpu_branch(save_game())
+    } else if(op_code == 6) {
+        # restore
+        cpu_branch(restore_game())
     } else if(op_code == 7) {
         # restart
         restart_game()


### PR DESCRIPTION
Adding code stubs to start the save and restore both as a placeholder and to stop the game from quitting if you attempt to save. It now simply returns fail.